### PR TITLE
Keep the username in a cookie

### DIFF
--- a/ruggedpod-api/server.py
+++ b/ruggedpod-api/server.py
@@ -46,6 +46,7 @@ def authenticate():
     token, expires = auth.get_token(request.args['username'],
                                     request.args['password'])
     response = make_response('', 201)
+    response.set_cookie('X-Auth-Username', request.args['username'], expires=expires)
     response.set_cookie('X-Auth-Token', token, expires=expires)
     return response
 


### PR DESCRIPTION
This is an easy way to show the username of the logged in user on the web frontend.
