### PR TITLE
Automate the operating system deployement

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -45,6 +45,7 @@ authentication:
     enabled: true
     secret_key: RASlAp4ILZi3rpqIMPCxrBoitx5QW4if5+naB8s2y30=
     token_lifetime: 3600
+    token_admin: Lj9MN6TlSWb6j6EvoZIJJYmUHENs2Oxr
 
 storage:
     file: /opt/ruggedpod-api/ruggedpod.db

--- a/ruggedpod_api/services/auth.py
+++ b/ruggedpod_api/services/auth.py
@@ -60,6 +60,9 @@ def get_token(username, password):
 
 
 def check(token):
+    if token == auth['token_admin']:
+        return
+
     identity = json.loads(security.Cipher(auth['secret_key']).decrypt(token))
 
     try:

--- a/ruggedpod_api/services/db.py
+++ b/ruggedpod_api/services/db.py
@@ -44,12 +44,15 @@ class Blade(DBObject):
     name = Column(String)
     description = Column(String)
     enabled = Column(Boolean)
+    mac_address = Column(String)
+    building = Column(Boolean, nullable=False)
 
     def __init__(self, id, name=None, description=None, enabled=True):
         self.id = id
         self.name = name
         self.description = description
         self.enabled = enabled
+        self.building = False
 
 
 class Database(object):


### PR DESCRIPTION
Automate the operating system installation. The workflow is somehow inspired from the [foreman](http://theforeman.org/) one.
## Workflow

**1 / Set the blade's MAC address**

Prior to PXE boot a blade to install the operating system, the blade's MAC address should have been set.

```
PUT /v2/blades/1

{
  "mac_address": "5c:cc:6b:01:b4:d3"
}
```

Now the blade looks something like

```
GET /v2/blades/1

{
  "building": false,
  "description": null,
  "consumption": 74,
  "mac_address": "5c:cc:6b:01:b4:d3",
  "id": 1,
  "name": null
}
```

The building status is set to `false`. It means the blade will not be (re)install on the next (re)boot. It the blade tries to boot over the network, the PXE will boot on the local hard drive.

**2 / Create the building configuration**

```
POST /v2/blades/1/build
```

Currently no specific configuration can be given. Only defaults will be used. At this point, nothing happens on the blade itself. The `building` flag on the blade is set to `true` and the PXE configuration for the blade is deployed (regarding its MAC address).

**3 / (Re)start the blade**

The blade will boot over the network and install the operating system (currently Ubuntu Trusty) using a preseed configuration. At the end of the process the installer will trigger a API call that indicate the installation is now complete.

```
DELETE /v2/blades/1/build
```

At this point the PXE configuration for the blade is disabled, the blade automatically reboot on the local hard drive.
## To do
- [x] Implement API
- [ ] Update API documentation
- [ ] Update firmware configuration
