### PR TITLE
Don't fail server startup on I2C error

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1,9 +1,3 @@
-consumption:
-    '1': 1
-    '2': 2
-    '3': 3
-    '4': 4
-
 reset:
     '1': 23
     '2': 21
@@ -29,7 +23,11 @@ long_press: 6
 i2c:
     bus: 1
     dac_power_consumption_addr : 0x6c
-    dac_other_addr : 0x6a
+    consumption:
+        '1': 1
+        '2': 2
+        '3': 3
+        '4': 4
 
 authentication:
     enabled: true

--- a/ruggedpod_api/api/v2_0/blades.py
+++ b/ruggedpod_api/api/v2_0/blades.py
@@ -28,7 +28,7 @@ from .blueprint import api
 
 from ruggedpod_api.api import utils
 from ruggedpod_api.common import exception
-from ruggedpod_api.services import gpio
+from ruggedpod_api.services import gpio, i2c
 from ruggedpod_api.services.db import Database, Blade, db
 
 from flask import request
@@ -51,7 +51,7 @@ def get_blades():
                 'building': b.building,
                 'mac_address': mac_address,
                 'ip_address': _read_ip_address(mac_address),
-                'consumption': gpio.read_power_consumption(str(b.id))
+                'consumption': i2c.read_power_consumption(str(b.id))
             })
         return json.dumps(blades)
 
@@ -84,7 +84,7 @@ def get_blade(id):
             'building': blade.building,
             'mac_address': mac_address,
             'ip_address': _read_ip_address(mac_address),
-            'consumption': gpio.read_power_consumption(str(blade.id))
+            'consumption': i2c.read_power_consumption(str(blade.id))
         })
 
 

--- a/ruggedpod_api/services/ADCPi/ABE_ADCPi.py
+++ b/ruggedpod_api/services/ADCPi/ABE_ADCPi.py
@@ -217,7 +217,8 @@ class ADCPi:
             self.__pga = 4
 
         self._bus.write_byte(self.__address, self.__config1)
-        self._bus.write_byte(self.__address2, self.__config2)
+        if self.__address2:
+            self._bus.write_byte(self.__address2, self.__config2)
         return
 
     def set_bit_rate(self, rate):
@@ -259,7 +260,8 @@ class ADCPi:
             self.__lsb = 0.0000078125
 
         self._bus.write_byte(self.__address, self.__config1)
-        self._bus.write_byte(self.__address2, self.__config2)
+        if self.__address2:
+            self._bus.write_byte(self.__address2, self.__config2)
         return
     
     def set_conversion_mode(self, mode):

--- a/ruggedpod_api/services/ADCPi/ABE_helpers.py
+++ b/ruggedpod_api/services/ADCPi/ABE_helpers.py
@@ -18,13 +18,11 @@ The bus object can then be used by multiple devices without conflicts.
 ================================================
 """
 
-i2c = config.get_attr('i2c')
-
 class ABEHelpers:
 
-    def get_smbus(self):
+    def get_smbus(self, bus):
         try:
-            return smbus.SMBus(i2c['bus'])
+            return smbus.SMBus(bus)
         except IOError:
                 print ("Could not open the i2c bus.")
                 print ("Please check that i2c is enabled and python-smbus and i2c-tools are installed.")

--- a/ruggedpod_api/services/gpio.py
+++ b/ruggedpod_api/services/gpio.py
@@ -23,18 +23,12 @@ from ruggedpod_api import config
 from ruggedpod_api.common import dependency
 
 
-consumption_dict = config.get_attr('consumption')
 reset_dict = config.get_attr('reset')
 onoff_dict = config.get_attr('onoff')
 short_press = config.get_attr('short_press')
 long_press = config.get_attr('long_press')
 serial_select_dict = config.get_attr('serial_select')
 oil_pump_dict = config.get_attr('oil_pump')
-i2c = config.get_attr('i2c')
-
-ADCHelpers = dependency.lookup('adc_helpers')
-ADCPi = dependency.lookup('adc')
-adc = ADCPi(ADCHelpers().get_smbus(), i2c['dac_power_consumption_addr'], i2c['dac_other_addr'], 12)
 
 GPIO = dependency.lookup('gpio')
 
@@ -49,10 +43,6 @@ def init():
     for blade_id in serial_select_dict:
         GPIO.setup(serial_select_dict[blade_id], GPIO.OUT)
         GPIO.output(serial_select_dict[blade_id], False)
-
-
-def read_power_consumption(blade_id):
-    return int((adc.read_raw(consumption_dict[blade_id]) * 2 / float(1000) - 2.5) * 10 * 24)
 
 
 def set_blade_short_onoff(blade_id):

--- a/ruggedpod_api/services/gpio_legacy.py
+++ b/ruggedpod_api/services/gpio_legacy.py
@@ -23,7 +23,6 @@ from ruggedpod_api import config
 from ruggedpod_api.common import dependency
 
 
-consumption_dict = config.get_attr('consumption')
 reset_dict = config.get_attr('reset')
 onoff_dict = config.get_attr('onoff')
 short_press = config.get_attr('short_press')
@@ -31,10 +30,11 @@ long_press = config.get_attr('long_press')
 serial_select_dict = config.get_attr('serial_select')
 oil_pump_dict = config.get_attr('oil_pump')
 i2c = config.get_attr('i2c')
+consumption_dict = i2c['consumption']
 
 ADCHelpers = dependency.lookup('adc_helpers')
 ADCPi = dependency.lookup('adc')
-adc = ADCPi(ADCHelpers().get_smbus(), i2c['dac_power_consumption_addr'], i2c['dac_other_addr'], 12)
+adc = ADCPi(ADCHelpers().get_smbus(i2c['bus']), i2c['dac_power_consumption_addr'], None, 12)
 
 GPIO = dependency.lookup('gpio')
 

--- a/ruggedpod_api/services/i2c.py
+++ b/ruggedpod_api/services/i2c.py
@@ -1,6 +1,6 @@
 # RuggedPOD management API
 #
-# Copyright (C) 2015 Guillaume Giamarchi <guillaume.giamarchi@gmail.com>
+# Copyright (C) 2016 Guillaume Giamarchi <guillaume.giamarchi@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,7 +15,18 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-from . import blueprint, authentication, blades, users, dhcp, i2c
-import ruggedpod_api.services.db as service_db
+from ruggedpod_api import config
+from ruggedpod_api.common import dependency
 
-service_db.db.init()
+
+i2c = config.get_attr('i2c')
+ADCHelpers = dependency.lookup('adc_helpers')
+ADCPi = dependency.lookup('adc')
+
+
+def read_power_consumption(blade_id):
+    try:
+        adc = ADCPi(ADCHelpers().get_smbus(i2c['bus']), i2c['dac_power_consumption_addr'], None, 12)
+        return int((adc.read_raw(i2c['consumption'][blade_id]) * 2 / float(1000) - 2.5) * 10 * 24)
+    except:
+        return -1


### PR DESCRIPTION
- If there's an I2C error, in any case the read power consumption will be -1
- Move I2C management in its own service
- Remove useless second device

Partial fix for #26 
