### PR TITLE
Add an API to execute commands on blades

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ SQLAlchemy==1.0.11
 Jinja2==2.8
 netaddr==0.7.18
 Beaker==1.8.0
+paramiko==2.0.2

--- a/ruggedpod_api/common/security.py
+++ b/ruggedpod_api/common/security.py
@@ -8,6 +8,10 @@ from Crypto import Random
 from . import singleton, exception
 
 
+def generate_uuid():
+    return uuid.uuid4().hex
+
+
 def hash_password(password):
     salt = uuid.uuid4().hex
     return hashlib.sha256(salt.encode() + password.encode()).hexdigest() + ':' + salt

--- a/ruggedpod_api/common/ssh.py
+++ b/ruggedpod_api/common/ssh.py
@@ -1,0 +1,25 @@
+import paramiko
+
+from StringIO import StringIO
+
+
+def execute(command, hostname, username, priv_key):
+
+    print("Execute command \"%s\" on host \"%s@%s\"" % (command, username, hostname))
+
+    k = paramiko.RSAKey.from_private_key(StringIO(priv_key))
+
+    c = paramiko.SSHClient()
+
+    c.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+
+    c.connect(hostname=hostname, username=username, pkey=k)
+
+    stdin, stdout, stderr = c.exec_command(command)
+
+    stdout_str = stdout.read()
+    stderr_str = stderr.read()
+
+    c.close()
+
+    return (0, stdout_str, stderr_str)


### PR DESCRIPTION
It consists in the following endpoints:

``` http
POST /blades/<blade_id>/commands
GET  /blades/<blade_id>/commands/<id>
GET  /blades/<blade_id>/commands
GET  /commands/<id>
GET  /commands
```

Commands are stored in the database, first to handle their lifecycle, then to keep track of the past commands. At any time a command can be requested to get information like its status (`PENDING`, `SUCCESS` or `ERROR`) or any other information stored in the database.

Currently, commands are always executed through SSH. Nevertheless, the API design does not lock-in to SSH. We could for example, run commands through the serial port.

Here is an example of a command submission

``` bash
curl -H "Content-Type: application/json" \
     -H "X-Auth-Token: ..." -X POST -d '
{
    "method": "ssh",
    "command": "sudo dmidecode",
    "username": "ruggedpod",
    "private_key": "..."
}' \
http://ruggedpod/api/v2/blades/3/commands
```
